### PR TITLE
building for macos with apple clang

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -24,8 +24,13 @@ CFLAGS+=-DNORMALUNIX -DLINUX
 OUTPUT=$(BINDIR)/doom_ascii
 endif
 
+ifeq ($(MAKECMDGOALS),mac)
+LDFLAGS+=-Wl,-dead_strip,-map,$(OUTPUT).map
+else
+LDFLAGS+=-Wl,--gc-sections,-Map,$(OUTPUT).map
+endif
+
 CFLAGS+=-Os -g
-LDFLAGS+=-Wl,--gc-sections
 CFLAGS+=-Wall -D_DEFAULT_SOURCE #-DSNDSERV -DUSEASM
 LIBS+=-lm
 
@@ -37,6 +42,8 @@ all:	 $(OUTPUT)
 
 windows: $(OUTPUT)
 
+mac: $(OUTPUT)
+
 clean:
 	rm -rf $(OBJDIR)
 	rm -f $(OUTPUT)
@@ -46,7 +53,7 @@ clean:
 $(OUTPUT):	$(OBJS) | $(BINDIR)
 	@echo [Linking $@]
 	$(VB)$(CC) $(CFLAGS) $(LDFLAGS) $(OBJS) \
-	-o $(OUTPUT) $(LIBS) -Wl,-Map,$(OUTPUT).map
+	-o $(OUTPUT) $(LIBS)
 	@echo [Size]
 	-$(CROSS_COMPILE)size $(OUTPUT)
 

--- a/src/doomgeneric_ascii.c
+++ b/src/doomgeneric_ascii.c
@@ -244,7 +244,7 @@ void DG_ReadInput(void)
 	memset(input_buffer, '\0', INPUT_BUFFER_LEN);
 	memset(event_buffer, '\0', 2u * EVENT_BUFFER_LEN);
 	event_buf_loc = event_buffer;
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || (defined(__APPLE__) && defined(__MACH__))
 	struct termios oldt, newt;
 
 	/* Disable canonical mode */

--- a/src/i_video.h
+++ b/src/i_video.h
@@ -136,6 +136,8 @@ void I_StartTic (void);
 
 void I_EnableLoadingDisk(void);
 
+void I_EndRead(void);
+
 extern char *video_driver;
 extern bool screenvisible;
 


### PR DESCRIPTION
Fixed
```
w_wad.c:364:5: error: implicit declaration of function 'I_EndRead' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    I_EndRead ();
```
by adding `I_EndRead ` declaration to `i_video.h`

Fixed unix macros detection based on http://web.archive.org/web/20160306052035/http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system

Added `make mac` target with linker options tweaked for apple clang
