### PR TITLE
compat: Use standard bool to resolve C99+ keyword conflicts

### DIFF
--- a/src/doomtype.h
+++ b/src/doomtype.h
@@ -65,9 +65,9 @@
 
 #include <inttypes.h>
 
-#if (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L) || defined __cplusplus
+#if (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L) || defined(__cplusplus)
 // For C99+ and C++, use the standard boolean type
-#  include <stdbool.h>
+#include <stdbool.h>
 #else
 // For older C standards, use the original custom enum
 typedef enum { false = 0, true = 1 } bool;


### PR DESCRIPTION
compilation fix for cstd23 (default in gcc 15)